### PR TITLE
Fix repository references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <div align="center">
 
-[![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/yourusername/depscan)
+[![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/therickybobbeh/dep-scanner)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![TypeScript](https://img.shields.io/badge/typescript-5.0+-blue.svg)](https://www.typescriptlang.org/)
 [![FastAPI](https://img.shields.io/badge/fastapi-0.104+-green.svg)](https://fastapi.tiangolo.com/)
 [![React](https://img.shields.io/badge/react-18.2+-61dafb.svg)](https://reactjs.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Coverage](https://img.shields.io/badge/coverage-90%25+-brightgreen)](https://github.com/yourusername/depscan)
+[![Coverage](https://img.shields.io/badge/coverage-90%25+-brightgreen)](https://github.com/therickybobbeh/dep-scanner)
 
 **Professional-grade dependency vulnerability scanner with CLI and web interfaces**
 
@@ -71,8 +71,8 @@ DepScan is a comprehensive dependency vulnerability scanner that helps developer
 **Option 1: Docker (Recommended)**
 ```bash
 # Clone and run with Docker Compose
-git clone https://github.com/yourusername/depscan.git
-cd depscan
+git clone https://github.com/therickybobbeh/dep-scanner.git
+cd dep-scanner
 docker-compose up --build
 
 # Access web interface at http://localhost:8000

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to DepScan! This guide will help you
 ## 🎯 Ways to Contribute
 
 ### 🐛 Bug Reports
-- Found a bug? [Open an issue](https://github.com/yourusername/depscan/issues)
+- Found a bug? [Open an issue](https://github.com/therickybobbeh/dep-scanner/issues)
 - Provide clear reproduction steps
 - Include system information and error messages
 - Check existing issues to avoid duplicates
@@ -37,11 +37,11 @@ Thank you for your interest in contributing to DepScan! This guide will help you
 
 ```bash
 # Fork on GitHub, then clone your fork
-git clone https://github.com/yourusername/depscan.git
-cd depscan
+git clone https://github.com/therickybobbeh/dep-scanner.git
+cd dep-scanner
 
 # Add upstream remote
-git remote add upstream https://github.com/original/depscan.git
+git remote add upstream https://github.com/therickybobbeh/dep-scanner.git
 ```
 
 ### 2. Development Setup

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -273,20 +273,20 @@ jobs:
           
       - name: Install DepScan
         run: |
-          git clone https://github.com/yourusername/depscan.git
-          cd depscan/backend
+          git clone https://github.com/therickybobbeh/dep-scanner.git
+          cd dep-scanner/backend
           pip install -r requirements.txt
           
       - name: Run Security Scan
         run: |
-          cd depscan
+          cd dep-scanner
           python backend/cli.py scan ${{ github.workspace }} --json security-report.json
           
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:
           name: security-report
-          path: depscan/security-report.json
+          path: dep-scanner/security-report.json
 ```
 
 #### Jenkins
@@ -302,17 +302,17 @@ pipeline {
                     python3 -m venv venv
                     source venv/bin/activate
                     
-                    git clone https://github.com/yourusername/depscan.git
-                    cd depscan/backend
+                    git clone https://github.com/therickybobbeh/dep-scanner.git
+                    cd dep-scanner/backend
                     pip install -r requirements.txt
                     
                     python cli.py scan ${WORKSPACE} --json security-report.json
                 '''
                 
-                archiveArtifacts artifacts: 'depscan/security-report.json'
+                archiveArtifacts artifacts: 'dep-scanner/security-report.json'
                 
                 script {
-                    def report = readJSON file: 'depscan/security-report.json'
+                    def report = readJSON file: 'dep-scanner/security-report.json'
                     if (report.vulnerable_count > 0) {
                         currentBuild.result = 'UNSTABLE'
                         echo "Found ${report.vulnerable_count} vulnerabilities"
@@ -449,7 +449,7 @@ rm backend/osv_cache.db
 1. **Verbose Output**: Add debug information to identify issues
 2. **Log Files**: Check backend logs for detailed error messages  
 3. **Test Environment**: Run `./run_tests.py` to verify installation
-4. **GitHub Issues**: Report bugs at [repository issues](https://github.com/yourusername/depscan/issues)
+4. **GitHub Issues**: Report bugs at [repository issues](https://github.com/therickybobbeh/dep-scanner/issues)
 
 ---
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -14,15 +14,15 @@ The fastest way to get DepScan running is with Docker Compose:
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/yourusername/depscan.git
-cd depscan
+git clone https://github.com/therickybobbeh/dep-scanner.git
+cd dep-scanner
 
 # 2. Start with Docker Compose
 docker-compose up --build
 
 # 3. Access interfaces
 # Web Interface: http://localhost:8000
-# CLI: docker exec -it depscan-backend python cli.py --help
+# CLI: docker exec -it dep-scanner-backend python cli.py --help
 ```
 
 ### Docker Compose Services
@@ -45,8 +45,8 @@ For development or when Docker isn't available:
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/yourusername/depscan.git
-cd depscan
+git clone https://github.com/therickybobbeh/dep-scanner.git
+cd dep-scanner
 
 # 2. Create Python virtual environment
 cd backend
@@ -273,7 +273,7 @@ If you encounter issues not covered here:
 
 1. **Check logs**: Backend logs show detailed error information
 2. **Run tests**: `./run_tests.py` can identify environment issues
-3. **GitHub Issues**: Report bugs at [repository issues](https://github.com/yourusername/depscan/issues)
+3. **GitHub Issues**: Report bugs at [repository issues](https://github.com/therickybobbeh/dep-scanner/issues)
 4. **Documentation**: Check [Architecture docs](../architecture/overview.md) for system details
 
 ---

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description="Dependency Vulnerability Scanner",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/example/depscan",
+    url="https://github.com/therickybobbeh/dep-scanner",
     packages=find_packages(),  # Changed to find packages in the root directory
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- replace placeholder repo URLs with `therickybobbeh/dep-scanner` across docs
- update contributing guide issue link and upstream remote
- point `setup.py` metadata to the correct GitHub repository

## Testing
- `PYTHONPATH=backend python -m pytest` *(fails: ModuleNotFoundError: No module named 'typer` during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6c1d764c832caaf9da8ffe373eb9