### PR TITLE
feat: improve CLI report and severity handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,15 @@ python backend/cli.py scan /path/to/project --json report.json
 python backend/cli.py scan . --include-dev --ignore-severity LOW
 ```
 
+**HTML Report:**
+```bash
+# Generate static HTML report and open it in your browser
+python backend/cli.py scan . --open
+```
+
 **Web Interface:**
 ```bash
-# Start web server
+# Start web server for interactive scanning
 cd backend && python -m uvicorn app.main:app --reload
 
 # Open browser to http://127.0.0.1:8000

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ python backend/cli.py scan . --include-dev --ignore-severity LOW
 
 **HTML Report:**
 ```bash
-# Generate static HTML report and open it in your browser
+# Generate static HTML report (dep-scan-report.html) and open it in your browser
+# The report file is replaced on each run
 python backend/cli.py scan . --open
 ```
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,2 @@
-from . import cli
+"""Backend package for dep-scan."""
+

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -54,7 +54,8 @@ python cli.py scan <PATH> [OPTIONS]
 - Example: `--ignore-severity LOW --ignore-severity MEDIUM`
 
 **`--open, -o`**
-- Generate static HTML report and open in browser after scan
+- Generate static HTML report (dep-scan-report.html) and open in browser after scan
+- The report file is replaced on each run
 - Useful for quick visual overview of results
 - Example: `--open`
 
@@ -142,7 +143,7 @@ Structured JSON report for integration and further processing.
       "severity": "HIGH",
       "cve_ids": ["CVE-2020-8203"],
       "summary": "Prototype Pollution in lodash",
-      "description": "lodash versions prior to 4.17.21 are vulnerable to Prototype Pollution.",
+      "details": "lodash versions prior to 4.17.21 are vulnerable to Prototype Pollution.",
       "advisory_url": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
       "fixed_range": ">=4.17.21",
       "published": "2020-05-08T18:25:00Z",

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -54,14 +54,9 @@ python cli.py scan <PATH> [OPTIONS]
 - Example: `--ignore-severity LOW --ignore-severity MEDIUM`
 
 **`--open, -o`**
-- Start web server and open browser after scan
-- Useful for interactive result exploration
+- Generate static HTML report and open in browser after scan
+- Useful for quick visual overview of results
 - Example: `--open`
-
-**`--port, -p <PORT>`**
-- Specify port for web server (when using `--open`)
-- Default: `8000`
-- Example: `--port 8080`
 
 #### Examples
 
@@ -81,8 +76,8 @@ python cli.py scan . --json detailed-report.json
 # Multiple options combined
 python cli.py scan ./backend --no-include-dev --ignore-severity LOW --json prod-security.json
 
-# Open web interface after scan
-python cli.py scan . --open --port 8080
+# Open HTML report after scan
+python cli.py scan . --open
 ```
 
 ### `version` Command

--- a/tests/unit/test_osv_scanner.py
+++ b/tests/unit/test_osv_scanner.py
@@ -97,26 +97,20 @@ class TestOSVScanner:
         assert isinstance(hash1, str) and len(hash1) > 0
 
     def test_extract_severity(self, osv_scanner):
-        # Test CVSS v3 scoring
-        severity_data = [
-            {
-                "type": "CVSS_V3", 
-                "score": 9.5
-            }
-        ]
+        # Test CVSS v3 scoring with numeric score
+        severity_data = [{"type": "CVSS_V3", "score": 9.5}]
         result = osv_scanner._extract_severity(severity_data)
         assert result == SeverityLevel.CRITICAL
-        
-        # Test medium severity
-        severity_data = [
-            {
-                "type": "CVSS_V3",
-                "score": 5.5
-            }
-        ]
+
+        # Test medium severity with string score
+        severity_data = [{"type": "CVSS_V3", "score": "5.5"}]
         result = osv_scanner._extract_severity(severity_data)
         assert result == SeverityLevel.MEDIUM
-        
+
+        # Test database_specific severity fallback
+        result = osv_scanner._extract_severity([], {"severity": "moderate"})
+        assert result == SeverityLevel.MEDIUM
+
         # Test empty list
         result = osv_scanner._extract_severity([])
         assert result == SeverityLevel.UNKNOWN

--- a/tests/unit/test_osv_scanner.py
+++ b/tests/unit/test_osv_scanner.py
@@ -111,6 +111,14 @@ class TestOSVScanner:
         result = osv_scanner._extract_severity([], {"severity": "moderate"})
         assert result == SeverityLevel.MEDIUM
 
+        # Test database_specific numeric score
+        result = osv_scanner._extract_severity([], {"score": "8.2"})
+        assert result == SeverityLevel.HIGH
+
+        # Test github_severity field
+        result = osv_scanner._extract_severity([], {"github_severity": "low"})
+        assert result == SeverityLevel.LOW
+
         # Test empty list
         result = osv_scanner._extract_severity([])
         assert result == SeverityLevel.UNKNOWN


### PR DESCRIPTION
## Summary
- parse severity from OSV `database_specific` field and numeric or string CVSS scores
- show direct vs transitive dependencies and generate HTML report via `--open`
- update docs for new `--open` behavior and fix CLI imports

## Testing
- `python run_tests.py` *(fails: 93 failed, 43 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8333b9e0832caf3e714fbe4cf561